### PR TITLE
Add additional logging to some creation and deletion events

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -301,6 +301,8 @@ public class RecordsStreamProducer extends RecordsProducer {
     }
 
     protected void generateCreateRecord(TableId tableId, Object[] rowData, BlockingConsumer<ChangeEvent> recordConsumer) throws InterruptedException {
+        // add more logging to 1 in 10,000 creation events
+        boolean enhancedDebug = Math.random() < 0.0001;
         if (rowData == null || rowData.length == 0) {
             logger.warn("no new values found for table '{}' from update message at '{}'; skipping record", tableId, sourceInfo);
             return;
@@ -319,9 +321,15 @@ public class RecordsStreamProducer extends RecordsProducer {
         Map<String, ?> offset = sourceInfo.offset();
         String topicName = topicSelector().topicNameFor(tableId);
         Envelope envelope = tableSchema.getEnvelopeSchema();
+        Struct source = sourceInfo.source();
 
         SourceRecord record = new SourceRecord(partition, offset, topicName, null, keySchema, key, envelope.schema(),
-                                               envelope.create(value, sourceInfo.source(), clock().currentTimeInMillis()));
+                                               envelope.create(value, source, clock().currentTimeInMillis()));
+
+        if (enhancedDebug) {
+            logger.info("[RECORD_DEBUG] Sending create record {} with source {} for topic {} at lsn {}", record, source, topicName, lastCompletelyProcessedLsn);
+        }
+
         if (logger.isDebugEnabled()) {
             logger.debug("sending create event '{}' to topic '{}'", record, topicName);
         }
@@ -401,6 +409,9 @@ public class RecordsStreamProducer extends RecordsProducer {
     }
 
     protected void generateDeleteRecord(TableId tableId, Object[] oldRowData, BlockingConsumer<ChangeEvent> recordConsumer) throws InterruptedException {
+        // add more logging to 1 in 1,000 deletion events
+        boolean enhancedDebug = Math.random() < 0.001;
+
         if (oldRowData == null || oldRowData.length == 0) {
             logger.warn("no values found for table '{}' from delete message at '{}'; skipping record" , tableId, sourceInfo);
             return;
@@ -418,16 +429,20 @@ public class RecordsStreamProducer extends RecordsProducer {
         Map<String, ?> offset = sourceInfo.offset();
         String topicName = topicSelector().topicNameFor(tableId);
         Envelope envelope = tableSchema.getEnvelopeSchema();
+        Struct source = sourceInfo.source();
 
         // create the regular delete record
         ChangeEvent changeEvent = new ChangeEvent(
                 new SourceRecord(
                         partition, offset, topicName, null,
                         keySchema, key, envelope.schema(),
-                        envelope.delete(value, sourceInfo.source(), clock().currentTimeInMillis())),
+                        envelope.delete(value, source, clock().currentTimeInMillis())),
                 lastCompletelyProcessedLsn);
         if (logger.isDebugEnabled()) {
             logger.debug("sending delete event '{}' to topic '{}'", changeEvent.getRecord(), topicName);
+        }
+        if (enhancedDebug) {
+            logger.info("[RECORD_DEBUG] Sending delete record {} with source {} for topic {} at lsn {}", changeEvent.getRecord(), source, topicName, lastCompletelyProcessedLsn);
         }
         recordConsumer.accept(changeEvent);
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -301,8 +301,8 @@ public class RecordsStreamProducer extends RecordsProducer {
     }
 
     protected void generateCreateRecord(TableId tableId, Object[] rowData, BlockingConsumer<ChangeEvent> recordConsumer) throws InterruptedException {
-        // add more logging to 1 in 10,000 creation events
-        boolean enhancedDebug = Math.random() < 0.0001;
+        // add more logging to 1 in 5,000 creation events
+        boolean enhancedDebug = Math.random() < 0.0002;
         if (rowData == null || rowData.length == 0) {
             logger.warn("no new values found for table '{}' from update message at '{}'; skipping record", tableId, sourceInfo);
             return;
@@ -409,8 +409,8 @@ public class RecordsStreamProducer extends RecordsProducer {
     }
 
     protected void generateDeleteRecord(TableId tableId, Object[] oldRowData, BlockingConsumer<ChangeEvent> recordConsumer) throws InterruptedException {
-        // add more logging to 1 in 1,000 deletion events
-        boolean enhancedDebug = Math.random() < 0.001;
+        // add more logging to 1 in 5,000 creation events
+        boolean enhancedDebug = Math.random() < 0.0002;
 
         if (oldRowData == null || oldRowData.length == 0) {
             logger.warn("no values found for table '{}' from delete message at '{}'; skipping record" , tableId, sourceInfo);


### PR DESCRIPTION
This adds some logging to 1/10000 create events, and 1/1000 delete events. This should help me figure out why `__lsn` is missing from delete events.

I picked 1/10000 and 1/1000 because I don't want to accidentally increase latency / resource utilization too much, but it seemed often enough to get a good stream of data. If it's not, I'll make adjustments.