### PR TITLE
Remove include-unchanged-toast param

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
@@ -92,7 +92,6 @@ public class NonStreamingWal2JsonMessageDecoder implements MessageDecoder {
 
     @Override
     public ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder) {
-        // return builder.withSlotOption("include-unchanged-toast", 0);
         return builder;
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
@@ -92,7 +92,8 @@ public class NonStreamingWal2JsonMessageDecoder implements MessageDecoder {
 
     @Override
     public ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder) {
-        return builder.withSlotOption("include-unchanged-toast", 0);
+        // return builder.withSlotOption("include-unchanged-toast", 0);
+        return builder;
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
@@ -268,7 +268,8 @@ public class StreamingWal2JsonMessageDecoder implements MessageDecoder {
 
     @Override
     public ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder) {
-        return builder.withSlotOption("include-unchanged-toast", 0);
+        // return builder.withSlotOption("include-unchanged-toast", 0);
+        return builder;
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
@@ -268,7 +268,6 @@ public class StreamingWal2JsonMessageDecoder implements MessageDecoder {
 
     @Override
     public ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder) {
-        // return builder.withSlotOption("include-unchanged-toast", 0);
         return builder;
     }
 


### PR DESCRIPTION
This is due to us running into issues for the Shipotle DB connectors.

@adriank-convoy found this workaround here: https://stackoverflow.com/questions/57607373/debezium-error-option-include-unchanged-toast-0-is-unknown