### PR TITLE
Add source fields (such as __lsn) for delete records

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/UnwrapFromEnvelope.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/UnwrapFromEnvelope.java
@@ -252,7 +252,8 @@ public class UnwrapFromEnvelope<R extends ConnectRecord<R>> implements Transform
                     return null;
                 case REWRITE:
                     logger.trace("Delete message {} requested to be rewritten", record.key());
-                    final R oldRecord = beforeDelegate.apply(record);
+                    R oldRecord = beforeDelegate.apply(record);
+                    oldRecord = addSourceFields(addSourceFields, record, oldRecord);
                     return removedDelegate.apply(oldRecord);
                 default:
                     return newRecord;


### PR DESCRIPTION
The `addSourceFields` call in the UnwrapFromEnvelope transformation copies certain debezium source fields (including `__lsn`) into the record. Our version of debezium was successfully adding these fields in the create record codepath, but it was missing in the delete record path.

This has been fixed in the latest version of Debezium: https://github.com/debezium/debezium/blob/master/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java#L158-L161

fixes https://convoy.atlassian.net/browse/DATA-226