### PR TITLE
Fix null pointer in log when LSN is null

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -191,8 +191,10 @@ public class PostgresConnectorTask extends BaseSourceTask {
         List<ChangeEvent> events = changeEventQueue.poll();
 
         if (events.size() > 0) {
-            ChangeEvent lastEvent = events.get(events.size() - 1);
-            logger.info("[LSN_DEBUG] {} - Polling {} events, with last event's lsn ending at: {}", this.databaseName, events.size(), LogSequenceNumber.valueOf(lastEvent.getLastCompletelyProcessedLsn()));
+            Long lastLsn = events.get(events.size() - 1).getLastCompletelyProcessedLsn();
+            if (lastLsn != null) {
+                logger.info("[LSN_DEBUG] {} - Polling {} events, with last event's lsn ending at: {}", this.databaseName, events.size(), LogSequenceNumber.valueOf(lastLsn));
+            }
         }
         return events.stream().map(ChangeEvent::getRecord).collect(Collectors.toList());
     }


### PR DESCRIPTION
Noticed that occasionally the postgres connector crashes with a null pointer exception when starting to tail a new table. This is because the lsn can be null (seems to only happen for a brand new connector/table). Let's just add a null check before logging to avoid this.

Tested by running local kafka, kafka-connect, and postgres with docker, and seeing no more null crash.