### PR TITLE
Track each LSN polled and committed, and flush the earliest one not yet committed

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -152,10 +152,14 @@ public class PostgresConnectorTask extends BaseSourceTask {
     public void commit() throws InterruptedException {
         if (running.get()) {
             Long earliestUnprocessedLsn = pendingLsnStore.getEarliestUnprocessedLsn();
+            Long largestProcessedLsn = pendingLsnStore.getLargestProcessedLsn();
             if (earliestUnprocessedLsn != null) {
                 logger.info("[LSN_DEBUG] Pending LSNs for connector {}: {}", taskName, pendingLsnStore);
                 logger.info("[LSN_DEBUG] Flushing LSN for connector {}: {}", taskName, LogSequenceNumber.valueOf(earliestUnprocessedLsn));
                 producer.commit(earliestUnprocessedLsn);
+            } else if (largestProcessedLsn != null) {
+                logger.info("[LSN_DEBUG] Committing with no pending LSNs, so flushing the largest seen so far for connector {}: {}", taskName, LogSequenceNumber.valueOf(largestProcessedLsn));
+                producer.commit(largestProcessedLsn);
             } else {
                 logger.info("[LSN_DEBUG] commit called without any new records");
             }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -41,6 +41,7 @@ public class PostgresConnectorTask extends BaseSourceTask {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final AtomicBoolean running = new AtomicBoolean(false);
 
+    private String taskName = "";
     private String databaseName = "";
     private PostgresTaskContext taskContext;
     private RecordsProducer producer;
@@ -62,6 +63,7 @@ public class PostgresConnectorTask extends BaseSourceTask {
 
         PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
         this.databaseName = connectorConfig.databaseName();
+        this.taskName = connectorConfig.getLogicalName();
 
         TypeRegistry typeRegistry;
         Charset databaseCharset;
@@ -151,7 +153,11 @@ public class PostgresConnectorTask extends BaseSourceTask {
         if (running.get()) {
             Long earliestUnprocessedLsn = pendingLsnStore.getEarliestUnprocessedLsn();
             if (earliestUnprocessedLsn != null) {
+                logger.info("[LSN_DEBUG] Pending LSNs for connector {}: {}", taskName, pendingLsnStore);
+                logger.info("[LSN_DEBUG] Flushing LSN for connector {}: {}", taskName, LogSequenceNumber.valueOf(earliestUnprocessedLsn));
                 producer.commit(earliestUnprocessedLsn);
+            } else {
+
             }
         }
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -151,14 +151,9 @@ public class PostgresConnectorTask extends BaseSourceTask {
     @Override
     public void commit() throws InterruptedException {
         if (running.get()) {
-            Long earliestUnprocessedLsn = pendingLsnStore.getEarliestUnprocessedLsn();
             Long largestProcessedLsn = pendingLsnStore.getLargestProcessedLsn();
-            if (earliestUnprocessedLsn != null) {
-                logger.info("[LSN_DEBUG] Pending LSNs for connector {}: {}", taskName, pendingLsnStore);
-                logger.info("[LSN_DEBUG] Flushing LSN for connector {}: {}", taskName, LogSequenceNumber.valueOf(earliestUnprocessedLsn));
-                producer.commit(earliestUnprocessedLsn);
-            } else if (largestProcessedLsn != null) {
-                logger.info("[LSN_DEBUG] Committing with no pending LSNs, so flushing the largest seen so far for connector {}: {}", taskName, LogSequenceNumber.valueOf(largestProcessedLsn));
+            if (largestProcessedLsn != null) {
+                logger.info("[LSN_DEBUG] Committing the largest processed LSN so far for connector {}: {}", taskName, LogSequenceNumber.valueOf(largestProcessedLsn));
                 producer.commit(largestProcessedLsn);
             } else {
                 logger.info("[LSN_DEBUG] commit called without any new records");

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -157,7 +157,7 @@ public class PostgresConnectorTask extends BaseSourceTask {
                 logger.info("[LSN_DEBUG] Flushing LSN for connector {}: {}", taskName, LogSequenceNumber.valueOf(earliestUnprocessedLsn));
                 producer.commit(earliestUnprocessedLsn);
             } else {
-
+                logger.info("[LSN_DEBUG] commit called without any new records");
             }
         }
     }
@@ -178,11 +178,10 @@ public class PostgresConnectorTask extends BaseSourceTask {
             }
         }
 
-        return events
-            .stream()
-            .map(ChangeEvent::getRecord)
-            .peek(pendingLsnStore::recordPolledLsn)
-            .collect(Collectors.toList());
+        List<SourceRecord> records = events.stream().map(ChangeEvent::getRecord).collect(Collectors.toList());
+        pendingLsnStore.recordPolledLsns(records);
+
+        return records;
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -154,7 +154,7 @@ public class PostgresConnectorTask extends BaseSourceTask {
             Long fullyProcessedLsn = pendingLsnStore.getFullyProcessedLsn();
             if (fullyProcessedLsn != null) {
                 logger.info("[LSN_DEBUG] Committing the largest fully processed LSN so far for connector {}: {}", taskName, LogSequenceNumber.valueOf(fullyProcessedLsn));
-                producer.commit(largestProcessedLsn);
+                producer.commit(fullyProcessedLsn);
             } else {
                 logger.info("[LSN_DEBUG] commit called without any new records");
             }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -151,9 +151,9 @@ public class PostgresConnectorTask extends BaseSourceTask {
     @Override
     public void commit() throws InterruptedException {
         if (running.get()) {
-            Long largestProcessedLsn = pendingLsnStore.getLargestProcessedLsn();
-            if (largestProcessedLsn != null) {
-                logger.info("[LSN_DEBUG] Committing the largest processed LSN so far for connector {}: {}", taskName, LogSequenceNumber.valueOf(largestProcessedLsn));
+            Long fullyProcessedLsn = pendingLsnStore.getFullyProcessedLsn();
+            if (fullyProcessedLsn != null) {
+                logger.info("[LSN_DEBUG] Committing the largest fully processed LSN so far for connector {}: {}", taskName, LogSequenceNumber.valueOf(fullyProcessedLsn));
                 producer.commit(largestProcessedLsn);
             } else {
                 logger.info("[LSN_DEBUG] commit called without any new records");

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPendingLsnStore.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPendingLsnStore.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+ package io.debezium.connector.postgresql;
+
+import java.util.Enumeration;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+public class PostgresPendingLsnStore {
+    private final ConcurrentHashMap<Long, Integer> lsnsInProgress = new ConcurrentHashMap<>();
+
+    public void recordPolledLsn(SourceRecord record) {
+        Long lsn = getLsnFromRecord(record);
+        if (lsn == null) {
+            return;
+        }
+
+        lsnsInProgress.compute(lsn, (_lsn, count) -> {
+            if (count == null) {
+                return 1;
+            } else {
+                return count + 1;
+            }
+        });
+    }
+
+    public void recordProcessedLsn(SourceRecord record) throws IllegalStateException {
+        Long lsn = getLsnFromRecord(record);
+        if (lsn == null) {
+            return;
+        }
+
+        lsnsInProgress.compute(lsn, (_lsn, count) -> {
+            if (count == null || count < 0) {
+                throw new IllegalStateException("Attempted to record processed LSN when it hasn't been polled");
+            } else if (count == 1) {
+                return null;
+            } else {
+                return count - 1;
+            }
+        });
+    }
+
+    public Long getEarliestUnprocessedLsn() {
+        // If there are no elements, return null
+        Enumeration<Long> lsnIterator = lsnsInProgress.keys();
+        if (!lsnIterator.hasMoreElements()) {
+            return null;
+        }
+
+        // Otherwise, iterate through each lsn to find the smallest
+        Long earliestLsn = lsnIterator.nextElement();
+        while (lsnIterator.hasMoreElements()) {
+            Long lsn = lsnIterator.nextElement();
+            if (lsn < earliestLsn) {
+                earliestLsn = lsn;
+            }
+        }
+
+        return earliestLsn;
+    }
+
+    private Long getLsnFromRecord(SourceRecord record) {
+        return (Long) record.sourceOffset().get(SourceInfo.LSN_KEY);
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPendingLsnStore.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPendingLsnStore.java
@@ -64,10 +64,10 @@ public class PostgresPendingLsnStore {
     }
 
     /**
-     * Get the largest LSN from an event comitted to Kafka so far.
+     * Get the largest LSN which has been processed, and for which all events before it have been processed.
      * @return the Long lsn value, or null if there are no events that have been processed yet.
      */
-    public Long getLargestProcessedLsn() {
+    public Long getFullyProcessedLsn() {
         Long earliestUnprocessedLsn = getEarliestUnprocessedLsn();
         Long largestProcessedLsn = getLargestProcessedLsnLessThan(earliestUnprocessedLsn);
         removeProcessedLsnsLessThan(largestProcessedLsn);
@@ -133,7 +133,9 @@ public class PostgresPendingLsnStore {
     }
 
     /**
-     * 
+     * Removes all processed lsns lower than the passed upper bound. This is a clean-up
+     * operation. The passed LSN should be the largest LSN that we've processed everything
+     * up through.
      */
     private void removeProcessedLsnsLessThan(Long upperBound) {
         if (upperBound == null) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPendingLsnStore.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPendingLsnStore.java
@@ -6,10 +6,12 @@
 
  package io.debezium.connector.postgresql;
 
+import java.io.StringWriter;
 import java.util.Enumeration;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.kafka.connect.source.SourceRecord;
+import org.postgresql.replication.LogSequenceNumber;
 
 public class PostgresPendingLsnStore {
     private final ConcurrentHashMap<Long, Integer> lsnsInProgress = new ConcurrentHashMap<>();
@@ -63,6 +65,16 @@ public class PostgresPendingLsnStore {
         }
 
         return earliestLsn;
+    }
+
+    public String toString() {
+        StringWriter sw = new StringWriter(50 + lsnsInProgress.size() * 22);
+        sw.append("PostgresPendingLsnStore (");
+        sw.append(Integer.toString(lsnsInProgress.size()));
+        sw.append(" items) [");
+        lsnsInProgress.forEach((lsn, count) -> sw.append(LogSequenceNumber.valueOf(lsn) + "=" + count + "; "));
+        sw.append("]");
+        return sw.toString();
     }
 
     private Long getLsnFromRecord(SourceRecord record) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPendingLsnStore.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPendingLsnStore.java
@@ -98,7 +98,8 @@ public class PostgresPendingLsnStore {
     }
 
     /**
-     * Get the earliest polled LSN from an event that has yet to be committed to Kafka.
+     * Get the largest committed LSN less than the passed upper bound. If no
+     * upper bound is passed, then just get the largest committed LSN.
      * @param upperBound
      * @return the Long lsn value, or null if there are no unprocessed LSNs
      */

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPendingLsnStore.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPendingLsnStore.java
@@ -4,9 +4,10 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
- package io.debezium.connector.postgresql;
+package io.debezium.connector.postgresql;
 
 import java.io.StringWriter;
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -29,6 +30,10 @@ public class PostgresPendingLsnStore {
                 return count + 1;
             }
         });
+    }
+
+    public void recordPolledLsns(Collection<SourceRecord> records) {
+        records.forEach(this::recordPolledLsn);
     }
 
     public void recordProcessedLsn(SourceRecord record) throws IllegalStateException {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPendingLsnStore.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPendingLsnStore.java
@@ -10,16 +10,16 @@ import java.io.StringWriter;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.kafka.connect.source.SourceRecord;
 import org.postgresql.replication.LogSequenceNumber;
 
 public class PostgresPendingLsnStore {
-    private final long LARGEST_PROCESSED_LSN_UNSET = -1;
+    private static final String LSN_PROCESSED = "LSN_PROCESSED";
 
     private final ConcurrentHashMap<Long, Integer> lsnsInProgress = new ConcurrentHashMap<>();
-    private final AtomicLong largestProcessedLsn = new AtomicLong(LARGEST_PROCESSED_LSN_UNSET);
+    private final ConcurrentHashMap<Long, String> lsnsProcessed = new ConcurrentHashMap<>();
 
     public void recordPolledLsn(SourceRecord record) {
         Long lsn = getLsnFromRecord(record);
@@ -46,24 +46,39 @@ public class PostgresPendingLsnStore {
             return;
         }
 
+        AtomicBoolean isFullyProcessed = new AtomicBoolean(false);
         lsnsInProgress.compute(lsn, (_lsn, count) -> {
             if (count == null || count < 0) {
                 throw new IllegalStateException("Attempted to record processed LSN when it hasn't been polled");
             } else if (count == 1) {
+                isFullyProcessed.set(true);
                 return null;
             } else {
                 return count - 1;
             }
         });
 
-        largestProcessedLsn.updateAndGet(currentLargestLsn -> Math.max(currentLargestLsn, lsn));
+        if (isFullyProcessed.get()) {
+            lsnsProcessed.put(lsn, LSN_PROCESSED);
+        }
+    }
+
+    /**
+     * Get the largest LSN from an event comitted to Kafka so far.
+     * @return the Long lsn value, or null if there are no events that have been processed yet.
+     */
+    public Long getLargestProcessedLsn() {
+        Long earliestUnprocessedLsn = getEarliestUnprocessedLsn();
+        Long largestProcessedLsn = getLargestProcessedLsnLessThan(earliestUnprocessedLsn);
+        removeProcessedLsnsLessThan(largestProcessedLsn);
+        return largestProcessedLsn;
     }
 
     /**
      * Get the earliest polled LSN from an event that has yet to be committed to Kafka.
      * @return the Long lsn value, or null if there are no unprocessed LSNs
      */
-    public Long getEarliestUnprocessedLsn() {
+    private Long getEarliestUnprocessedLsn() {
         // If there are no elements, return null
         Enumeration<Long> lsnIterator = lsnsInProgress.keys();
         if (!lsnIterator.hasMoreElements()) {
@@ -83,25 +98,62 @@ public class PostgresPendingLsnStore {
     }
 
     /**
-     * Get the largest LSN from an event comitted to Kafka so far.
-     * @return the Long lsn value, or null if there are no events that have been processed yet.
+     * Get the earliest polled LSN from an event that has yet to be committed to Kafka.
+     * @param upperBound
+     * @return the Long lsn value, or null if there are no unprocessed LSNs
      */
-    public Long getLargestProcessedLsn() {
-        Long value = largestProcessedLsn.get();
-        if (value == LARGEST_PROCESSED_LSN_UNSET) {
+    private Long getLargestProcessedLsnLessThan(Long upperBound) {
+        // If there was no upper bound passed in, then set it to Long.MAX_VALUE
+        // so that we get the largest processed lsn so far
+        if (upperBound == null) {
+            upperBound = Long.MAX_VALUE;
+        }
+
+        // Define a const for no matching LSN found, and initialize the largest
+        // lsn to that constant
+        final Long NO_MATCH = -1L;
+        Long largestLsnInBounds = NO_MATCH;
+
+        // Iterate through the processed LSNs to find the largest one that's
+        // less than the upper bound
+        Enumeration<Long> lsnsProcessedIterator = lsnsProcessed.keys();
+        while (lsnsProcessedIterator.hasMoreElements()) {
+            Long lsn = lsnsProcessedIterator.nextElement();
+            if (lsn > largestLsnInBounds && lsn < upperBound) {
+                largestLsnInBounds = lsn;
+            }
+        }
+
+        // Return the largest matching LSN, or null if none was found
+        if (largestLsnInBounds == NO_MATCH) {
             return null;
         } else {
-            return value;
+            return largestLsnInBounds;
         }
     }
 
+    /**
+     * 
+     */
+    private void removeProcessedLsnsLessThan(Long upperBound) {
+        if (upperBound == null) {
+            return;
+        }
+
+        lsnsProcessed.keySet().removeIf((lsn) -> lsn < upperBound);
+    }
+
     public String toString() {
-        StringWriter sw = new StringWriter(50 + lsnsInProgress.size() * 22);
-        sw.append("PostgresPendingLsnStore (");
+        StringWriter sw = new StringWriter(92 + lsnsInProgress.size() * 24 + lsnsProcessed.size() * 20);
+        sw.append("PostgresPendingLsnStore [lsnsInProgress (");
         sw.append(Integer.toString(lsnsInProgress.size()));
         sw.append(" items) [");
         lsnsInProgress.forEach((lsn, count) -> sw.append(LogSequenceNumber.valueOf(lsn) + "=" + count + "; "));
-        sw.append("]");
+        sw.append("]; lsnsProcessed (");
+        sw.append(Integer.toString(lsnsProcessed.size()));
+        sw.append(" items) [");
+        lsnsProcessed.forEach((lsn, count) -> sw.append(LogSequenceNumber.valueOf(lsn) + "; "));
+        sw.append("]]");
         return sw.toString();
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresPendingLsnStoreIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresPendingLsnStoreIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+/**
+ * Integration test for {@link public class PostgresPendingLsnStore} class.
+ */
+public class PostgresPendingLsnStoreIT {
+
+    @Test
+    public void shouldReturnNullOnInitialization() throws Exception {
+        PostgresPendingLsnStore lsnStore = new PostgresPendingLsnStore();
+        assertNull(lsnStore.getFullyProcessedLsn());
+    }
+
+    @Test
+    public void shouldReturnNullWhenNothingProcessed() throws Exception {
+        PostgresPendingLsnStore lsnStore = new PostgresPendingLsnStore();
+        lsnStore.recordPolledLsn(mockSourceRecord(1));
+        assertNull(lsnStore.getFullyProcessedLsn());
+    }
+
+    @Test
+    public void shouldReturnNullIfHaveNotProcessedSmallestLsn() throws Exception {
+        // Generate the store and mocked records
+        PostgresPendingLsnStore lsnStore = new PostgresPendingLsnStore();
+        SourceRecord mock1 = mockSourceRecord(1);
+        SourceRecord mock2 = mockSourceRecord(2);
+        SourceRecord mock3 = mockSourceRecord(3);
+
+        // Poll 3 LSNs, and process the largest 2 of them
+        lsnStore.recordPolledLsns(Arrays.asList(mock1, mock2, mock3));
+        lsnStore.recordProcessedLsn(mock2);
+        lsnStore.recordProcessedLsn(mock3);
+
+        // Expect null
+        assertNull(lsnStore.getFullyProcessedLsn());
+    }
+
+    @Test
+    public void shouldReturnLargestProcessedWhenAllProcessed() throws Exception {
+        // Generate the store and mocked records
+        PostgresPendingLsnStore lsnStore = new PostgresPendingLsnStore();
+        SourceRecord mock1 = mockSourceRecord(1);
+        SourceRecord mock2 = mockSourceRecord(2);
+        SourceRecord mock3 = mockSourceRecord(3);
+        SourceRecord mock4 = mockSourceRecord(4);
+
+        // Poll 4 LSNs, and process all of them
+        lsnStore.recordPolledLsns(Arrays.asList(mock1, mock2, mock3, mock4));
+        lsnStore.recordProcessedLsn(mock4);
+        lsnStore.recordProcessedLsn(mock1);
+        lsnStore.recordProcessedLsn(mock3);
+        lsnStore.recordProcessedLsn(mock2);
+
+        // Expect the largest LSN to return
+        assertEquals(new Long(4), lsnStore.getFullyProcessedLsn());
+    }
+
+    @Test
+    public void shouldReturnLargestProcessedWithGap() throws Exception {
+        // Generate the store and mocked records
+        PostgresPendingLsnStore lsnStore = new PostgresPendingLsnStore();
+        SourceRecord mock1 = mockSourceRecord(1);
+        SourceRecord mock2 = mockSourceRecord(2);
+        SourceRecord mock3 = mockSourceRecord(3);
+        SourceRecord mock4 = mockSourceRecord(4);
+
+        // Poll 4 LSNs, and process only 3 of them (with a gap, and out of order)
+        lsnStore.recordPolledLsns(Arrays.asList(mock1, mock2, mock3, mock4));
+        lsnStore.recordProcessedLsn(mock4);
+        lsnStore.recordProcessedLsn(mock1);
+        lsnStore.recordProcessedLsn(mock2);
+
+        // Expect the 2nd LSN to be the largest processed, since all below it are also processed
+        // Should return the same value, even after multiple calls
+        assertEquals(new Long(2), lsnStore.getFullyProcessedLsn());
+        assertEquals(new Long(2), lsnStore.getFullyProcessedLsn());
+    }
+
+    @Test
+    public void shouldKeepStateAcrossCommits() throws Exception {
+        // Generate the store and mocked records
+        PostgresPendingLsnStore lsnStore = new PostgresPendingLsnStore();
+        SourceRecord mock1 = mockSourceRecord(1);
+        SourceRecord mock2 = mockSourceRecord(2);
+        SourceRecord mock3 = mockSourceRecord(3);
+        SourceRecord mock4 = mockSourceRecord(4);
+        SourceRecord mock5 = mockSourceRecord(5);
+        SourceRecord mock6 = mockSourceRecord(6);
+
+        // Poll 4 LSNs, and process only 3 of them (with a gap, and out of order)
+        lsnStore.recordPolledLsns(Arrays.asList(mock1, mock2, mock3, mock4));
+        lsnStore.recordProcessedLsn(mock3);
+        lsnStore.recordPolledLsns(Arrays.asList(mock5));
+        lsnStore.recordProcessedLsn(mock1);
+        assertEquals(new Long(1), lsnStore.getFullyProcessedLsn());
+
+        lsnStore.recordProcessedLsn(mock5);
+        lsnStore.recordProcessedLsn(mock2);
+        assertEquals(new Long(3), lsnStore.getFullyProcessedLsn());
+
+        lsnStore.recordProcessedLsn(mock4);
+        assertEquals(new Long(5), lsnStore.getFullyProcessedLsn());
+
+        lsnStore.recordPolledLsns(Arrays.asList(mock6));
+        assertEquals(new Long(5), lsnStore.getFullyProcessedLsn());
+
+        lsnStore.recordProcessedLsn(mock6);
+        assertEquals(new Long(6), lsnStore.getFullyProcessedLsn());
+    }
+
+    private static SourceRecord mockSourceRecord(long lsn) {
+        Map<String, Long> sourceOffset = Collections.singletonMap(SourceInfo.LSN_KEY, lsn);
+        return new SourceRecord(null, sourceOffset, null, null, null);
+    }
+}


### PR DESCRIPTION
We currently are having issues (still) of LSN's that are too large getting committed, because we assumed that `commitRecord` would be called sequentially. That seems to be true _within_ a topic, but not between multiple topics written from the same database, because Kafka will produce to multiple topics in parallel.

The approach here (thanks to @adriank-convoy) is to keep track of every LSN that gets polled, and then when that LSN's record gets committed (via `poll` and `commitRecord`). When `commit` is called, we find the smallest LSN that has yet to be committed, and we flush that to Postgres.