### PR TITLE
Remove skip logic based on lsn

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -260,18 +260,13 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             @Override
             public void read(ReplicationMessageProcessor processor) throws SQLException, InterruptedException {
                 ByteBuffer read = stream.read();
-                // the lsn we started from is inclusive, so we need to avoid sending back the same message twice
-                if (lsnLong >= stream.getLastReceiveLSN().asLong()) {
-                    return;
-                }
                 deserializeMessages(read, processor);
             }
 
             @Override
             public void readPending(ReplicationMessageProcessor processor) throws SQLException, InterruptedException {
                 ByteBuffer read = stream.readPending();
-                // the lsn we started from is inclusive, so we need to avoid sending back the same message twice
-                if (read == null ||  lsnLong >= stream.getLastReceiveLSN().asLong()) {
+                if (read == null) {
                     return;
                 }
                 deserializeMessages(read, processor);


### PR DESCRIPTION
# What!?

Making the same change the reporter of https://issues.redhat.com/browse/DBZ-2397 made, which makes sense. We're in the same boat in that we can handle duplicate messages, but need at least once delivery. See the issue for more details.