### PR TITLE
EventRouter cherry-pick

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -6,11 +6,15 @@
 
 package io.debezium.connector.postgresql;
 
-import io.debezium.config.Configuration;
-import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
-import io.debezium.data.Uuid;
-import io.debezium.embedded.AbstractConnectorTest;
-import io.debezium.transforms.outbox.EventRouter;
+import static io.debezium.connector.postgresql.TestHelper.topicName;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.header.Header;
@@ -22,14 +26,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
-import static io.debezium.connector.postgresql.TestHelper.topicName;
-import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
-import static org.fest.assertions.Assertions.assertThat;
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.data.Uuid;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.transforms.outbox.EventRouter;
 
 /**
  * Integration test for {@link io.debezium.transforms.outbox.EventRouter} with {@link PostgresConnector}
@@ -149,7 +150,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
     public void shouldSupportAllFeatures() throws Exception {
         outboxEventRouter = new EventRouter<>();
         final Map<String, String> config = new HashMap<>();
-        config.put("table.field.schema.version", "version");
+        config.put("table.field.event.schema.version", "version");
         config.put("table.field.event.timestamp", "createdat");
         config.put(
                 "table.fields.additional.placement",

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -146,7 +146,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
                 "UserCreated",
                 "User",
                 "10711fa5",
-                "{}",
+                "{\"email\": \"gh@mefi.in\"}",
                 ""
         ));
 
@@ -166,11 +166,11 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         assertThat(routedEvent).isNotNull();
         assertThat(routedEvent.topic()).isEqualTo("outbox.event.user");
 
-        Struct valueStruct = requireStruct(routedEvent.value(), "test payload");
+        Object value = routedEvent.value();
         assertThat(routedEvent.headers().lastWithName("eventType").value()).isEqualTo("UserCreated");
-        assertThat(valueStruct.schema().field("eventType")).isNull();
-        JsonNode payload = (new ObjectMapper()).readTree(valueStruct.getString("payload"));
-        assertThat(payload.get("email")).isEqualTo(null);
+        assertThat(value).isInstanceOf(String.class);
+        JsonNode payload = (new ObjectMapper()).readTree((String) value);
+        assertThat(payload.get("email").getTextValue()).isEqualTo("gh@mefi.in");
 
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -93,7 +93,10 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
     }
 
     @Before
-    public void beforeEach() {
+    public void beforeEach() {        
+        //TestHelper.dropDefaultReplicationSlot();
+        //TestHelper.dropPublication();
+        
         outboxEventRouter = new EventRouter<>();
         outboxEventRouter.configure(Collections.emptyMap());
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -13,6 +13,7 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -134,7 +134,13 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         SourceRecord routedEvent = outboxEventRouter.apply(newEventRecord);
 
         assertThat(routedEvent).isNotNull();
-        assertThat(routedEvent.topic()).isEqualTo("outbox.event.user");
+        assertThat(routedEvent.topic()).isEqualTo("outbox.event.User");
+
+        Struct valueStruct = requireStruct(routedEvent.value(), "test payload");
+        assertThat(valueStruct.getString("eventType")).isEqualTo("UserCreated");
+        JsonNode payload = (new ObjectMapper()).readTree(valueStruct.getString("payload"));
+        assertThat(payload.get("email")).isEqualTo(null);
+
     }
 
     @Test
@@ -164,7 +170,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         SourceRecord routedEvent = outboxEventRouter.apply(newEventRecord);
 
         assertThat(routedEvent).isNotNull();
-        assertThat(routedEvent.topic()).isEqualTo("outbox.event.user");
+        assertThat(routedEvent.topic()).isEqualTo("outbox.event.User");
 
         Object value = routedEvent.value();
         assertThat(routedEvent.headers().lastWithName("eventType").value()).isEqualTo("UserCreated");
@@ -245,7 +251,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         assertConnectSchemasAreEqual(null, eventRouted.valueSchema(), expectedSchema);
 
         assertThat(eventRouted.timestamp()).isEqualTo(1553460779000000L);
-        assertThat(eventRouted.topic()).isEqualTo("outbox.event.useremail");
+        assertThat(eventRouted.topic()).isEqualTo("outbox.event.UserEmail");
 
         // Validate headers
         Headers headers = eventRouted.headers();
@@ -310,7 +316,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         // Validate metadata
         assertThat(eventRouted.valueSchema()).isNotNull();
         assertThat(eventRouted.timestamp()).isEqualTo(1553460779000000L);
-        assertThat(eventRouted.topic()).isEqualTo("outbox.event.useremail");
+        assertThat(eventRouted.topic()).isEqualTo("outbox.event.UserEmail");
 
         // Validate headers
         Headers headers = eventRouted.headers();
@@ -373,7 +379,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         // Validate metadata
         assertThat(eventRouted.valueSchema()).isNull();
         assertThat(eventRouted.timestamp()).isEqualTo(1553460779000000L);
-        assertThat(eventRouted.topic()).isEqualTo("outbox.event.useremail");
+        assertThat(eventRouted.topic()).isEqualTo("outbox.event.UserEmail");
 
         // Validate headers
         Headers headers = eventRouted.headers();
@@ -420,7 +426,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
 
         // Validate metadata
         assertThat(eventRouted.valueSchema()).isNull();
-        assertThat(eventRouted.topic()).isEqualTo("outbox.event.useremail");
+        assertThat(eventRouted.topic()).isEqualTo("outbox.event.UserEmail");
 
         // Validate headers
         Headers headers = eventRouted.headers();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -136,8 +136,11 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         assertThat(routedEvent).isNotNull();
         assertThat(routedEvent.topic()).isEqualTo("outbox.event.User");
 
+        assertThat(routedEvent.keySchema()).isEqualTo(Schema.STRING_SCHEMA);
+        assertThat(routedEvent.key()).isEqualTo("10711fa5");
+
         Struct valueStruct = requireStruct(routedEvent.value(), "test payload");
-        assertThat(valueStruct.schema().name()).isEqualTo("test_server.outboxsmtit.outbox.Value-outbox");
+        assertThat(valueStruct.schema().name()).isEqualTo("test_server.outboxsmtit.outbox.User.Value");
         assertThat(valueStruct.getString("eventType")).isEqualTo("UserCreated");
         JsonNode payload = (new ObjectMapper()).readTree(valueStruct.getString("payload"));
         assertThat(payload.get("email")).isEqualTo(null);
@@ -239,7 +242,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         // Validate metadata
         Schema expectedSchema = SchemaBuilder.struct()
                 .version(1)
-                .name("test_server.outboxsmtit.outbox.Value-outbox")
+                .name("test_server.outboxsmtit.outbox.UserEmail.Value")
                 .field("payload", Json.builder().optional().build())
                 .field("eventType", Schema.STRING_SCHEMA)
                 .field("eventVersion", Schema.INT32_SCHEMA)
@@ -473,37 +476,6 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
 
         // Validate message body
         assertThat(eventRouted.value()).isNull();
-    }
-
-    @Test
-    @FixFor("DBZ-1963")
-    public void shouldEmitValueSchemaWithNonDefaultName() throws Exception {
-        outboxEventRouter = new EventRouter<>();
-        final Map<String, String> config = new HashMap<>();
-        config.put("debezium.schema.name.suffix", "-outbox-non-default");
-        outboxEventRouter.configure(config);
-
-        startConnectorWithInitialSnapshotRecord();
-
-        TestHelper.execute(createEventInsert(
-                UUID.fromString("59a42efd-b015-44a9-9dde-cb36d9002425"),
-                "UserCreated",
-                "User",
-                "10711fa5",
-                "{}",
-                ""));
-
-        SourceRecords actualRecords = consumeRecordsByTopic(1);
-        assertThat(actualRecords.topics().size()).isEqualTo(1);
-
-        SourceRecord newEventRecord = actualRecords.recordsForTopic(topicName("outboxsmtit.outbox")).get(0);
-        SourceRecord routedEvent = outboxEventRouter.apply(newEventRecord);
-
-        assertThat(routedEvent).isNotNull();
-        assertThat(routedEvent.topic()).isEqualTo("outbox.event.User");
-
-        Struct valueStruct = requireStruct(routedEvent.value(), "test payload");
-        assertThat(valueStruct.schema().name()).isEqualTo("test_server.outboxsmtit.outbox.Value-outbox-non-default");
     }
 
     private void startConnectorWithInitialSnapshotRecord() throws Exception {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -138,6 +138,43 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
     }
 
     @Test
+    public void shouldSendEventTypeAsHeader() throws Exception {
+        startConnectorWithInitialSnapshotRecord();
+
+        TestHelper.execute(createEventInsert(
+                UUID.fromString("59a42efd-b015-44a9-9dde-cb36d9002425"),
+                "UserCreated",
+                "User",
+                "10711fa5",
+                "{}",
+                ""
+        ));
+
+        final Map<String, String> config = new HashMap<>();
+        config.put(
+                "table.fields.additional.placement",
+                "type:header:eventType"
+        );
+        outboxEventRouter.configure(config);
+
+        SourceRecords actualRecords = consumeRecordsByTopic(1);
+        assertThat(actualRecords.topics().size()).isEqualTo(1);
+
+        SourceRecord newEventRecord = actualRecords.recordsForTopic(topicName("outboxsmtit.outbox")).get(0);
+        SourceRecord routedEvent = outboxEventRouter.apply(newEventRecord);
+
+        assertThat(routedEvent).isNotNull();
+        assertThat(routedEvent.topic()).isEqualTo("outbox.event.user");
+
+        Struct valueStruct = requireStruct(routedEvent.value(), "test payload");
+        assertThat(routedEvent.headers().lastWithName("eventType").value()).isEqualTo("UserCreated");
+        assertThat(valueStruct.schema().field("eventType")).isNull();
+        JsonNode payload = (new ObjectMapper()).readTree(valueStruct.getString("payload"));
+        assertThat(payload.get("email")).isEqualTo(null);
+
+    }
+
+    @Test
     public void shouldRespectJsonFormatAsString() throws Exception {
         TestHelper.execute(createEventInsert(
                 UUID.fromString("f9171eb6-19f3-4579-9206-0e179d2ebad7"),
@@ -197,8 +234,8 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         // Validate metadata
         Schema expectedSchema = SchemaBuilder.struct()
                 .version(1)
-                .field("eventType", Schema.STRING_SCHEMA)
                 .field("payload", Json.builder().optional().build())
+                .field("eventType", Schema.STRING_SCHEMA)
                 .field("eventVersion", Schema.INT32_SCHEMA)
                 .field("aggregateType", Schema.STRING_SCHEMA)
                 .field("someBoolType", Schema.BOOLEAN_SCHEMA)

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -232,4 +232,22 @@ public final class TestHelper {
     protected static int waitTimeForRecords() {
         return Integer.parseInt(System.getProperty(TEST_PROPERTY_PREFIX + "records.waittime", "2"));
     }
+
+    protected static void dropDefaultReplicationSlot() {
+        try {
+            execute("SELECT pg_drop_replication_slot('" + ReplicationConnection.Builder.DEFAULT_SLOT_NAME + "')");
+        }
+        catch (Exception e) {
+            System.out.println("Error while dropping default replication slot" + e.toString());
+        }
+    }
+
+    protected static void dropPublication() {
+        try {
+            execute("DROP PUBLICATION pgoutput");
+        }
+        catch (Exception e) {
+            System.out.println("Error while dropping publication: 'pgoutput'" + e.toString());
+        }
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/connector/AbstractSourceInfo.java
+++ b/debezium-core/src/main/java/io/debezium/connector/AbstractSourceInfo.java
@@ -19,6 +19,13 @@ import org.apache.kafka.connect.data.Struct;
 public abstract class AbstractSourceInfo {
     public static final String DEBEZIUM_VERSION_KEY = "version";
     public static final String DEBEZIUM_CONNECTOR_KEY = "connector";
+    public static final String SERVER_NAME_KEY = "name";
+    public static final String TIMESTAMP_KEY = "ts_ms";
+    public static final String SNAPSHOT_KEY = "snapshot";
+    public static final String DATABASE_NAME_KEY = "db";
+    public static final String SCHEMA_NAME_KEY = "schema";
+    public static final String TABLE_NAME_KEY = "table";
+    public static final String COLLECTION_NAME_KEY = "collection";
 
     private final String version;
 

--- a/debezium-core/src/main/java/io/debezium/transforms/SmtManager.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/SmtManager.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms;
+
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+
+/**
+ * A class used by all Debezium supplied SMTs to centralize common logic.
+ *
+ * @param <R> the subtype of {@link ConnectRecord} on which the transformation will operate
+ * @author Jiri Pechanec
+ */
+public class SmtManager<R extends ConnectRecord<R>> {
+
+    private static final String ENVELOPE_SCHEMA_NAME_SUFFIX = ".Envelope";
+    private static final String RECORD_ENVELOPE_KEY_SCHEMA_NAME_SUFFIX = ".Key";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SmtManager.class);
+
+    public SmtManager(Configuration config) {
+    }
+
+    public boolean isValidEnvelope(final R record) {
+        if (record.valueSchema() == null ||
+                record.valueSchema().name() == null ||
+                !record.valueSchema().name().endsWith(ENVELOPE_SCHEMA_NAME_SUFFIX)) {
+            LOGGER.warn("Expected Envelope for transformation, passing it unchanged");
+            return false;
+        }
+        return true;
+    }
+
+    public boolean isValidKey(final R record) {
+        if (record.keySchema() == null ||
+                record.keySchema().name() == null ||
+                !record.keySchema().name().endsWith(RECORD_ENVELOPE_KEY_SCHEMA_NAME_SUFFIX)) {
+            LOGGER.warn("Expected Key Schema for transformation, passing it unchanged. Message key: \"{}\"", record.key());
+            return false;
+        }
+        return true;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -41,7 +41,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventRouter.class);
 
-    private static final String ENVELOPE_EVENT_TYPE = "eventType";
+    public static final String ENVELOPE_EVENT_TYPE = "eventType";
     private static final String ENVELOPE_PAYLOAD = "payload";
     private static final String RECORD_ENVELOPE_SCHEMA_NAME_SUFFIX = ".Envelope";
 
@@ -51,7 +51,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
 
     private String fieldEventId;
     private String fieldEventKey;
-    private String fieldEventType;
     private String fieldEventTimestamp;
     private String fieldPayload;
     private String fieldPayloadId;
@@ -106,7 +105,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
                 : eventStruct.getInt64(fieldEventTimestamp);
 
         Object eventId = eventStruct.get(fieldEventId);
-        Object eventType = eventStruct.get(fieldEventType);
         Object payload = eventStruct.get(fieldPayload);
         Object payloadId = eventStruct.get(fieldPayloadId);
 
@@ -118,7 +116,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
                 : getValueSchema(eventValueSchema, eventStruct.getInt32(fieldSchemaVersion));
 
         Struct value = new Struct(valueSchema)
-                .put(ENVELOPE_EVENT_TYPE, eventType)
                 .put(ENVELOPE_PAYLOAD, payload);
 
         additionalFields.forEach((additionalField -> {
@@ -211,7 +208,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
 
         fieldEventId = config.getString(EventRouterConfigDefinition.FIELD_EVENT_ID);
         fieldEventKey = config.getString(EventRouterConfigDefinition.FIELD_EVENT_KEY);
-        fieldEventType = config.getString(EventRouterConfigDefinition.FIELD_EVENT_TYPE);
         fieldEventTimestamp = config.getString(EventRouterConfigDefinition.FIELD_EVENT_TIMESTAMP);
         fieldPayload = config.getString(EventRouterConfigDefinition.FIELD_PAYLOAD);
         fieldPayloadId = config.getString(EventRouterConfigDefinition.FIELD_PAYLOAD_ID);
@@ -257,7 +253,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
 
         // Add default fields
         schemaBuilder
-                .field(ENVELOPE_EVENT_TYPE, debeziumEventSchema.field(fieldEventType).schema())
                 .field(ENVELOPE_PAYLOAD, debeziumEventSchema.field(fieldPayload).schema());
 
         // Add additional fields while keeping the schema inherited from Debezium based on the table column type

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -113,8 +113,8 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         Long timestamp = getEventTimestampMs(debeziumEventValue, eventStruct);
         Object eventId = eventStruct.get(fieldEventId);
         Object payload = eventStruct.get(fieldPayload);
-        Object payloadId = eventStruct.get(fieldPayloadId);
         final Field fallbackPayloadIdField = eventValueSchema.field(fieldPayloadId);
+        Object payloadId = fallbackPayloadIdField != null ? eventStruct.get(fieldPayloadId) : null;
 
         final Field eventIdField = eventValueSchema.field(fieldEventId);
         if (eventIdField == null) {

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -169,7 +169,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         }
 
         R newRecord = r.newRecord(
-                eventStruct.getString(routeByField).toLowerCase(),
+                eventStruct.getString(routeByField),
                 null,
                 Schema.STRING_SCHEMA,
                 defineRecordKey(eventStruct, payloadId),

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -65,7 +65,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
     private List<AdditionalField> additionalFields;
 
     private Schema defaultValueSchema;
-    private String valueSchemaSuffix;
     private final Map<Integer, Schema> versionedValueSchema = new HashMap<>();
 
     private boolean onlyHeadersInOutputMessage = false;
@@ -124,10 +123,10 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         Headers headers = r.headers();
         headers.add("id", eventId, eventIdField.schema());
 
-        final Schema structValueSchema = onlyHeadersInOutputMessage ? null :
-            (fieldSchemaVersion == null)
-                ? getValueSchema(eventValueSchema)
-                : getValueSchema(eventValueSchema, eventStruct.getInt32(fieldSchemaVersion));
+        final Schema structValueSchema = onlyHeadersInOutputMessage ? null
+                : (fieldSchemaVersion == null)
+                        ? getValueSchema(eventValueSchema, eventStruct.getString(routeByField))
+                        : getValueSchema(eventValueSchema, eventStruct.getInt32(fieldSchemaVersion), eventStruct.getString(routeByField));
 
         final Struct structValue = onlyHeadersInOutputMessage ? null :
             new Struct(structValueSchema).put(ENVELOPE_PAYLOAD, payload);
@@ -274,7 +273,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         fieldSchemaVersion = config.getString(EventRouterConfigDefinition.FIELD_SCHEMA_VERSION);
         routeByField = config.getString(EventRouterConfigDefinition.ROUTE_BY_FIELD);
         routeTombstoneOnEmptyPayload = config.getBoolean(EventRouterConfigDefinition.ROUTE_TOMBSTONE_ON_EMPTY_PAYLOAD);
-        valueSchemaSuffix = config.getString(EventRouterConfigDefinition.SCHEMA_NAME_SUFFIX);
 
         final Map<String, String> regexRouterConfig = new HashMap<>();
         regexRouterConfig.put("regex", config.getString(EventRouterConfigDefinition.ROUTE_TOPIC_REGEX));
@@ -291,17 +289,17 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         onlyHeadersInOutputMessage = !additionalFields.stream().anyMatch(field -> field.getPlacement() == EventRouterConfigDefinition.AdditionalFieldPlacement.ENVELOPE);
     }
 
-    private Schema getValueSchema(Schema debeziumEventSchema) {
+    private Schema getValueSchema(Schema debeziumEventSchema, String routedTopic) {
         if (defaultValueSchema == null) {
-            defaultValueSchema = getSchemaBuilder(debeziumEventSchema).build();
+            defaultValueSchema = getSchemaBuilder(debeziumEventSchema, routedTopic).build();
         }
 
         return defaultValueSchema;
     }
 
-    private Schema getValueSchema(Schema debeziumEventSchema, Integer version) {
+    private Schema getValueSchema(Schema debeziumEventSchema, Integer version, String routedTopic) {
         if (!versionedValueSchema.containsKey(version)) {
-            final Schema schema = getSchemaBuilder(debeziumEventSchema)
+            final Schema schema = getSchemaBuilder(debeziumEventSchema, routedTopic)
                     .version(version)
                     .build();
             versionedValueSchema.put(version, schema);
@@ -310,8 +308,8 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         return versionedValueSchema.get(version);
     }
 
-    private SchemaBuilder getSchemaBuilder(Schema debeziumEventSchema) {
-        SchemaBuilder schemaBuilder = SchemaBuilder.struct().name(debeziumEventSchema.name() + valueSchemaSuffix);
+    private SchemaBuilder getSchemaBuilder(Schema debeziumEventSchema, String routedTopic) {
+        SchemaBuilder schemaBuilder = SchemaBuilder.struct().name(getSchemaName(debeziumEventSchema, routedTopic));
 
         // Add payload field
         schemaBuilder
@@ -328,5 +326,23 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         }));
 
         return schemaBuilder;
+    }
+
+    private String getSchemaName(Schema debeziumEventSchema, String routedTopic) {
+        final String schemaName;
+        final String originalSchemaName = debeziumEventSchema.name();
+        if (originalSchemaName != null) {
+            final int lastDot = originalSchemaName.lastIndexOf('.');
+            if (lastDot != -1) {
+                schemaName = originalSchemaName.substring(0, lastDot + 1) + routedTopic + "." + originalSchemaName.substring(lastDot + 1);
+            }
+            else {
+                schemaName = routedTopic + "." + originalSchemaName;
+            }
+        }
+        else {
+            schemaName = routedTopic;
+        }
+        return schemaName;
     }
 }

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -65,6 +65,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
     private List<AdditionalField> additionalFields;
 
     private Schema defaultValueSchema;
+    private String valueSchemaSuffix;
     private final Map<Integer, Schema> versionedValueSchema = new HashMap<>();
 
     private boolean onlyHeadersInOutputMessage = false;
@@ -273,6 +274,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         fieldSchemaVersion = config.getString(EventRouterConfigDefinition.FIELD_SCHEMA_VERSION);
         routeByField = config.getString(EventRouterConfigDefinition.ROUTE_BY_FIELD);
         routeTombstoneOnEmptyPayload = config.getBoolean(EventRouterConfigDefinition.ROUTE_TOMBSTONE_ON_EMPTY_PAYLOAD);
+        valueSchemaSuffix = config.getString(EventRouterConfigDefinition.SCHEMA_NAME_SUFFIX);
 
         final Map<String, String> regexRouterConfig = new HashMap<>();
         regexRouterConfig.put("regex", config.getString(EventRouterConfigDefinition.ROUTE_TOPIC_REGEX));
@@ -309,7 +311,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
     }
 
     private SchemaBuilder getSchemaBuilder(Schema debeziumEventSchema) {
-        SchemaBuilder schemaBuilder = SchemaBuilder.struct();
+        SchemaBuilder schemaBuilder = SchemaBuilder.struct().name(debeziumEventSchema.name() + valueSchemaSuffix);
 
         // Add payload field
         schemaBuilder

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -114,6 +114,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         Object eventId = eventStruct.get(fieldEventId);
         Object payload = eventStruct.get(fieldPayload);
         Object payloadId = eventStruct.get(fieldPayloadId);
+        final Field fallbackPayloadIdField = eventValueSchema.field(fieldPayloadId);
 
         final Field eventIdField = eventValueSchema.field(fieldEventId);
         if (eventIdField == null) {
@@ -171,7 +172,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         R newRecord = r.newRecord(
                 eventStruct.getString(routeByField),
                 null,
-                Schema.STRING_SCHEMA,
+                defineRecordKeySchema(eventValueSchema, fallbackPayloadIdField),
                 defineRecordKey(eventStruct, payloadId),
                 updatedSchema,
                 updatedValue,
@@ -218,6 +219,19 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
             default:
                 throw new ConnectException(String.format("Unsupported field type %s for event timestamp", schemaName));
         }
+    }
+
+    private Schema defineRecordKeySchema(Schema eventStruct, Field fallbackKeyField) {
+        Field eventKeySchema = null;
+        if (fieldEventKey != null) {
+            eventKeySchema = eventStruct.field(fieldEventKey);
+        }
+
+        if (eventKeySchema != null) {
+            return eventKeySchema.schema();
+        }
+
+        return (fallbackKeyField != null) ? fallbackKeyField.schema() : Schema.STRING_SCHEMA;
     }
 
     private Object defineRecordKey(Struct eventStruct, Object fallbackKey) {

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -29,6 +29,9 @@ import org.slf4j.LoggerFactory;
 import io.debezium.annotation.Incubating;
 import io.debezium.config.Configuration;
 import io.debezium.data.Envelope;
+import io.debezium.time.MicroTimestamp;
+import io.debezium.time.NanoTimestamp;
+import io.debezium.time.Timestamp;
 import io.debezium.transforms.SmtManager;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.AdditionalField;
 
@@ -107,10 +110,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         }
         Schema payloadSchema = payloadField.schema();
 
-        Long timestamp = fieldEventTimestamp == null
-                ? debeziumEventValue.getInt64("ts_ms")
-                : eventStruct.getInt64(fieldEventTimestamp);
-
+        Long timestamp = getEventTimestampMs(debeziumEventValue, eventStruct);
         Object eventId = eventStruct.get(fieldEventId);
         Object payload = eventStruct.get(fieldPayload);
         Object payloadId = eventStruct.get(fieldPayloadId);
@@ -180,6 +180,44 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         );
 
         return regexRouter.apply(newRecord);
+    }
+
+    /**
+     * Returns the Kafka record timestamp for the outgoing record.
+     * Either obtained from the configured field or the timestamp when Debezium processed the event.
+     */
+    private Long getEventTimestampMs(Struct debeziumEventValue, Struct eventStruct) {
+        if (fieldEventTimestamp == null) {
+            return debeziumEventValue.getInt64("ts_ms");
+        }
+
+        Field timestampField = eventStruct.schema().field(fieldEventTimestamp);
+        if (timestampField == null) {
+            throw new ConnectException(String.format("Unable to find timestamp field %s in event", fieldEventTimestamp));
+        }
+
+        Long timestamp = eventStruct.getInt64(fieldEventTimestamp);
+        if (timestamp == null) {
+            return debeziumEventValue.getInt64("ts_ms");
+        }
+
+        String schemaName = timestampField.schema().name();
+
+        if (schemaName == null) {
+            throw new ConnectException(String.format("Unsupported field type %s (without logical schema name) for event timestamp", timestampField.schema().type()));
+        }
+
+        // not going through Instant here for the sake of performance
+        switch (schemaName) {
+            case Timestamp.SCHEMA_NAME:
+                return timestamp;
+            case MicroTimestamp.SCHEMA_NAME:
+                return timestamp / 1_000;
+            case NanoTimestamp.SCHEMA_NAME:
+                return timestamp / 1_000_000;
+            default:
+                throw new ConnectException(String.format("Unsupported field type %s for event timestamp", schemaName));
+        }
     }
 
     private Object defineRecordKey(Struct eventStruct, Object fallbackKey) {

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -209,6 +209,14 @@ public class EventRouterConfigDefinition {
                     " '${routedByValue}' is available which is the value of The column configured" +
                     " via 'route.by.field'");
 
+    static final Field ROUTE_TOMBSTONE_ON_EMPTY_PAYLOAD = Field.create("route.tombstone.on.empty.payload")
+            .withDisplayName("Empty payloads cause a tombstone message")
+            .withType(ConfigDef.Type.BOOLEAN)
+            .withDefault(false)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("Whether or not an empty payload should cause a tombstone event.");
+
     static final Field OPERATION_INVALID_BEHAVIOR = Field.create("debezium.op.invalid.behavior")
             .withDisplayName("Behavior when the route fails to apply")
             .withEnum(InvalidOperationBehavior.class, InvalidOperationBehavior.SKIP_AND_WARN)
@@ -230,6 +238,7 @@ public class EventRouterConfigDefinition {
             ROUTE_BY_FIELD,
             ROUTE_TOPIC_REGEX,
             ROUTE_TOPIC_REPLACEMENT,
+            ROUTE_TOMBSTONE_ON_EMPTY_PAYLOAD,
             OPERATION_INVALID_BEHAVIOR
     };
 
@@ -251,7 +260,7 @@ public class EventRouterConfigDefinition {
         Field.group(
                 config,
                 "Router",
-                ROUTE_BY_FIELD, ROUTE_TOPIC_REGEX, ROUTE_TOPIC_REPLACEMENT
+                ROUTE_BY_FIELD, ROUTE_TOPIC_REGEX, ROUTE_TOPIC_REPLACEMENT, ROUTE_TOMBSTONE_ON_EMPTY_PAYLOAD
         );
         Field.group(
                 config,

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -5,13 +5,14 @@
  */
 package io.debezium.transforms.outbox;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.kafka.common.config.ConfigDef;
+
 import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
-import org.apache.kafka.common.config.ConfigDef;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Debezium Outbox Transform configuration definition
@@ -121,14 +122,14 @@ public class EventRouterConfigDefinition {
             .withWidth(ConfigDef.Width.MEDIUM)
             .withImportance(ConfigDef.Importance.LOW)
             .withDefault("id")
-            .withDescription("The column which contains the Event ID within the outbox table");
+            .withDescription("The column which contains the event ID within the outbox table");
 
     static final Field FIELD_EVENT_KEY = Field.create("table.field.event.key")
             .withDisplayName("Event Key Field")
             .withType(ConfigDef.Type.STRING)
             .withWidth(ConfigDef.Width.MEDIUM)
             .withImportance(ConfigDef.Importance.LOW)
-            .withDescription("The column which contains the Event Key within the outbox table");
+            .withDescription("The column which contains the event key within the outbox table");
 
     static final Field FIELD_EVENT_TYPE = Field.create("table.field.event.type")
             .withDisplayName("Event Type Field")
@@ -136,7 +137,7 @@ public class EventRouterConfigDefinition {
             .withWidth(ConfigDef.Width.MEDIUM)
             .withImportance(ConfigDef.Importance.LOW)
             .withDefault("type")
-            .withDescription("The column which contains the Event Type within the outbox table");
+            .withDescription("The column which contains the event type within the outbox table");
 
     static final Field FIELD_EVENT_TIMESTAMP = Field.create("table.field.event.timestamp")
             .withDisplayName("Event Timestamp Field")
@@ -144,23 +145,23 @@ public class EventRouterConfigDefinition {
             .withWidth(ConfigDef.Width.MEDIUM)
             .withImportance(ConfigDef.Importance.MEDIUM)
             .withDescription("Optionally you can override the Kafka message timestamp with a value from a chosen" +
-                    " field, otherwise it'll be the debezium event processed timestamp.");
+                    " column, otherwise it'll be the Debezium event processed timestamp.");
 
-    static final Field FIELD_PAYLOAD = Field.create("table.field.payload")
+    static final Field FIELD_PAYLOAD = Field.create("table.field.event.payload")
             .withDisplayName("Event Payload Field")
             .withType(ConfigDef.Type.STRING)
             .withWidth(ConfigDef.Width.MEDIUM)
             .withImportance(ConfigDef.Importance.LOW)
             .withDefault("payload")
-            .withDescription("The column which contains the Event Type within the outbox table");
+            .withDescription("The column which contains the event payload within the outbox table");
 
-    static final Field FIELD_PAYLOAD_ID = Field.create("table.field.payload.id")
+    static final Field FIELD_PAYLOAD_ID = Field.create("table.field.event.payload.id")
             .withDisplayName("Event Payload ID Field")
             .withType(ConfigDef.Type.STRING)
             .withWidth(ConfigDef.Width.MEDIUM)
             .withImportance(ConfigDef.Importance.LOW)
             .withDefault("aggregateid")
-            .withDescription("The column which contains the Payload ID within the outbox table");
+            .withDescription("The column which contains the payload ID within the outbox table");
 
     static final Field FIELDS_ADDITIONAL_PLACEMENT = Field.create("table.fields.additional.placement")
             .withDisplayName("Settings for each additional column in the outbox table")
@@ -172,12 +173,12 @@ public class EventRouterConfigDefinition {
                     " is a list of colon-delimited pairs or trios when you desire to have aliases," +
                     " e.g. <code>id:header,field_name:envelope:alias</code> ");
 
-    static final Field FIELD_SCHEMA_VERSION = Field.create("table.field.schema.version")
+    static final Field FIELD_SCHEMA_VERSION = Field.create("table.field.event.schema.version")
             .withDisplayName("Event Schema Version Field")
             .withType(ConfigDef.Type.STRING)
             .withWidth(ConfigDef.Width.MEDIUM)
             .withImportance(ConfigDef.Importance.LOW)
-            .withDescription("The column which contains the Schema version within the outbox table");
+            .withDescription("The column which contains the event schema version within the outbox table");
 
     static final Field ROUTE_BY_FIELD = Field.create("route.by.field")
             .withDisplayName("Field to route events by")

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -271,11 +271,8 @@ public class EventRouterConfigDefinition {
 
     static List<AdditionalField> parseAdditionalFieldsConfig(Configuration config) {
         String extraFieldsMapping = config.getString(EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT);
-        String eventTypeColumn = config.getString(FIELD_EVENT_TYPE);
-
         List<AdditionalField> additionalFields = new ArrayList<>();
 
-        boolean eventTypeMappingProvided = false;
         if (extraFieldsMapping != null) {
             for (String field : extraFieldsMapping.split(",")) {
                 final String[] parts = field.split(":");
@@ -283,13 +280,7 @@ public class EventRouterConfigDefinition {
                 AdditionalFieldPlacement placement = AdditionalFieldPlacement.parse(parts[1]);
                 final AdditionalField addField = new AdditionalField(placement, fieldName, parts.length == 3 ? parts[2] : fieldName);
                 additionalFields.add(addField);
-                if (EventRouter.ENVELOPE_EVENT_TYPE.equals(addField.getAlias())) {
-                    eventTypeMappingProvided = true;
-                }
             }
-        }
-        if (!eventTypeMappingProvided) {
-            additionalFields.add(0, new AdditionalField(AdditionalFieldPlacement.ENVELOPE, eventTypeColumn, EventRouter.ENVELOPE_EVENT_TYPE));
         }
 
         return additionalFields;
@@ -313,4 +304,4 @@ public class EventRouterConfigDefinition {
         }
         return errors;
     }
-}
+} 

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -226,13 +226,6 @@ public class EventRouterConfigDefinition {
                     " in case something else is processed this transform can log it as warning, error or stop the" +
                     " process");
 
-    static final Field SCHEMA_NAME_SUFFIX = Field.create("debezium.schema.name.suffix")
-            .withDisplayName("The suffix to append to value schema")
-            .withDefault("-outbox")
-            .withWidth(ConfigDef.Width.MEDIUM)
-            .withImportance(ConfigDef.Importance.MEDIUM)
-            .withDescription("A suffix that is appended to the source message value schema for the emitted outbox message");
-
     static final Field[] CONFIG_FIELDS = {
             FIELD_EVENT_ID,
             FIELD_EVENT_KEY,
@@ -246,8 +239,7 @@ public class EventRouterConfigDefinition {
             ROUTE_TOPIC_REGEX,
             ROUTE_TOPIC_REPLACEMENT,
             ROUTE_TOMBSTONE_ON_EMPTY_PAYLOAD,
-            OPERATION_INVALID_BEHAVIOR,
-            SCHEMA_NAME_SUFFIX
+            OPERATION_INVALID_BEHAVIOR
     };
 
     /**
@@ -273,7 +265,7 @@ public class EventRouterConfigDefinition {
         Field.group(
                 config,
                 "Debezium",
-                OPERATION_INVALID_BEHAVIOR, SCHEMA_NAME_SUFFIX);
+                OPERATION_INVALID_BEHAVIOR);
         return config;
     }
 

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -226,6 +226,13 @@ public class EventRouterConfigDefinition {
                     " in case something else is processed this transform can log it as warning, error or stop the" +
                     " process");
 
+    static final Field SCHEMA_NAME_SUFFIX = Field.create("debezium.schema.name.suffix")
+            .withDisplayName("The suffix to append to value schema")
+            .withDefault("-outbox")
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("A suffix that is appended to the source message value schema for the emitted outbox message");
+
     static final Field[] CONFIG_FIELDS = {
             FIELD_EVENT_ID,
             FIELD_EVENT_KEY,
@@ -239,7 +246,8 @@ public class EventRouterConfigDefinition {
             ROUTE_TOPIC_REGEX,
             ROUTE_TOPIC_REPLACEMENT,
             ROUTE_TOMBSTONE_ON_EMPTY_PAYLOAD,
-            OPERATION_INVALID_BEHAVIOR
+            OPERATION_INVALID_BEHAVIOR,
+            SCHEMA_NAME_SUFFIX
     };
 
     /**
@@ -265,8 +273,7 @@ public class EventRouterConfigDefinition {
         Field.group(
                 config,
                 "Debezium",
-                OPERATION_INVALID_BEHAVIOR
-        );
+                OPERATION_INVALID_BEHAVIOR, SCHEMA_NAME_SUFFIX);
         return config;
     }
 

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -6,6 +6,7 @@
 package io.debezium.transforms.outbox;
 
 import io.debezium.data.Envelope;
+import io.debezium.data.VerifyRecord;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -526,6 +527,103 @@ public class EventRouterTest {
         router.configure(config);
     }
 
+    @Test
+    public void canMarkAnEventAsDeleted() {
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        config.put(
+                EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT.name(),
+                "is_deleted:envelope:deleted"
+        );
+        config.put(
+                EventRouterConfigDefinition.ROUTE_TOMBSTONE_ON_EMPTY_PAYLOAD.name(),
+                "true"
+        );
+        router.configure(config);
+
+        final Map<String, Schema> extraFields = new HashMap<>();
+        extraFields.put("deleted", Schema.OPTIONAL_BOOLEAN_SCHEMA);
+
+        final Map<String, Object> extraValues = new HashMap<>();
+        extraValues.put("is_deleted", true);
+
+        final SourceRecord eventRecord = createEventRecord(
+                "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
+                "UserCreated",
+                "10711fa5",
+                "User",
+                "{}",
+                extraFields,
+                extraValues);
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        Struct value = (Struct) eventRouted.value();
+        assertThat(value).isNotNull();
+        assertThat(value.get("deleted")).isEqualTo(true);
+
+        final SourceRecord eventRecordTombstone = createEventRecord(
+                "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
+                "UserCreated",
+                "10711fa5",
+                "User",
+                "",
+                extraFields,
+                extraValues);
+        final SourceRecord eventRoutedTombstone = router.apply(eventRecordTombstone);
+
+        Struct tombstone = (Struct) eventRoutedTombstone.value();
+        assertThat(tombstone).isNull();
+        VerifyRecord.isValidTombstone(eventRoutedTombstone);
+    }
+
+    @Test
+    public void noTombstoneIfNotConfigured() {
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        config.put(
+                EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT.name(),
+                "is_deleted:envelope:deleted"
+        );
+        router.configure(config);
+
+        final Map<String, Schema> extraFields = new HashMap<>();
+        extraFields.put("deleted", Schema.OPTIONAL_BOOLEAN_SCHEMA);
+
+        final Map<String, Object> extraValues = new HashMap<>();
+        extraValues.put("is_deleted", true);
+
+        final SourceRecord eventRecord = createEventRecord(
+                "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
+                "UserCreated",
+                "10711fa5",
+                "User",
+                "{}",
+                extraFields,
+                extraValues);
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        Struct value = (Struct) eventRouted.value();
+        assertThat(value).isNotNull();
+        assertThat(value.get("deleted")).isEqualTo(true);
+
+        final SourceRecord eventRecordTombstone = createEventRecord(
+                "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
+                "UserCreated",
+                "10711fa5",
+                "User",
+                "",
+                extraFields,
+                extraValues);
+        final SourceRecord eventRoutedTombstone = router.apply(eventRecordTombstone);
+
+        Struct tombstone = (Struct) eventRoutedTombstone.value();
+        assertThat(eventRoutedTombstone.key()).isNotNull();
+        assertThat(eventRoutedTombstone.keySchema()).isNotNull();
+        assertThat(tombstone).isNotNull();
+        assertThat(tombstone.get("deleted")).isEqualTo(true);
+        assertThat(eventRoutedTombstone.valueSchema()).isNotNull();
+    }
+
     private SourceRecord createEventRecord() {
         return createEventRecord(
                 "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
@@ -568,7 +666,8 @@ public class EventRouterTest {
                 .field("aggregatetype", SchemaBuilder.string())
                 .field("aggregateid", SchemaBuilder.string())
                 .field("type", SchemaBuilder.string())
-                .field("payload", SchemaBuilder.string());
+                .field("payload", SchemaBuilder.string())
+                .field("is_deleted", SchemaBuilder.bool().optional());
 
         extraFields.forEach(schemaBuilder::field);
 

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -114,7 +114,7 @@ public class EventRouterTest {
 
         final SourceRecord eventRouted = router.apply(eventRecord);
 
-        assertThat(eventRouted).isNull();
+        assertThat(eventRouted).isSameAs(eventRecord);
     }
 
     @Test
@@ -174,7 +174,7 @@ public class EventRouterTest {
 
         final SourceRecord eventRouted = router.apply(eventRecord);
 
-        assertThat(eventRouted).isNull();
+        assertThat(eventRouted).isSameAs(eventRecord);
     }
 
     @Test
@@ -204,7 +204,7 @@ public class EventRouterTest {
 
         final SourceRecord eventRouted = router.apply(eventRecord);
 
-        assertThat(eventRouted).isNull();
+        assertThat(eventRouted).isSameAs(eventRecord);
     }
 
     @Test

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -5,11 +5,16 @@
  */
 package io.debezium.transforms.outbox;
 
-import io.debezium.connector.AbstractSourceInfo;
-import io.debezium.data.Envelope;
-import io.debezium.data.VerifyRecord;
-import io.debezium.doc.FixFor;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -654,6 +659,82 @@ public class EventRouterTest {
     }
 
     @Test
+    public void canPassStringKey() {
+        // canSetDefaultMessageKey() duplicates this logic, as the current test assumes the key will be a String
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        router.configure(config);
+
+        final SourceRecord eventRecord = createEventRecord();
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        assertThat(eventRouted).isNotNull();
+        assertThat(eventRouted.keySchema().type()).isEqualTo(Schema.Type.STRING);
+    }
+
+    @Test
+    public void canPassBinaryKey() {
+        final byte[] key = "a binary key".getBytes(StandardCharsets.UTF_8);
+        canPassKeyByType(SchemaBuilder.bytes(), key);
+    }
+
+    @Test
+    public void canPassIntKey() {
+        final int key = 54321;
+        canPassKeyByType(SchemaBuilder.int32(), key);
+    }
+
+    private void canPassKeyByType(SchemaBuilder keyType, Object key) {
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        router.configure(config);
+
+        final SourceRecord eventRecord = createEventRecord(
+                "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
+                "UserCreated",
+                keyType,
+                key,
+                "User",
+                SchemaBuilder.string(),
+                "{}",
+                new HashMap<>(),
+                new HashMap<>());
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        assertThat(eventRouted).isNotNull();
+        assertThat(eventRouted.keySchema().type()).isEqualTo(keyType.type());
+        assertThat(eventRouted.key()).isEqualTo(key);
+    }
+
+    @Test
+    public void canPassBinaryMessage() {
+        final byte[] value = "a binary message".getBytes(StandardCharsets.UTF_8);
+        final String key = "a key";
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        router.configure(config);
+
+        final SourceRecord eventRecord = createEventRecord(
+                "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
+                "UserCreated",
+                SchemaBuilder.string(),
+                key,
+                "User",
+                SchemaBuilder.bytes(),
+                value,
+                new HashMap<>(),
+                new HashMap<>());
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        assertThat(eventRouted).isNotNull();
+        assertThat(eventRouted.keySchema().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(eventRouted.key()).isEqualTo(key);
+        assertThat(eventRouted.valueSchema().type()).isEqualTo(Schema.Type.STRUCT);
+        Struct valuePassed = (Struct) eventRouted.value();
+        assertThat(valuePassed.get("payload")).isEqualTo(value);
+    }
+
+    @Test
     public void canMarkAnEventAsDeleted() {
         final EventRouter<SourceRecord> router = new EventRouter<>();
         final Map<String, String> config = new HashMap<>();
@@ -779,20 +860,41 @@ public class EventRouterTest {
     }
 
     private SourceRecord createEventRecord(
-            String eventId,
-            String eventType,
-            String payloadId,
-            String payloadType,
-            String payload,
-            Map<String, Schema> extraFields,
-            Map<String, Object> extraValues
-    ) {
+                                           String eventId,
+                                           String eventType,
+                                           String payloadId,
+                                           String payloadType,
+                                           String payload,
+                                           Map<String, Schema> extraFields,
+                                           Map<String, Object> extraValues) {
+        return createEventRecord(
+                eventId,
+                eventType,
+                SchemaBuilder.string(),
+                payloadId,
+                payloadType,
+                SchemaBuilder.string(),
+                payload,
+                extraFields,
+                extraValues);
+    }
+
+    private SourceRecord createEventRecord(
+                                           String eventId,
+                                           String eventType,
+                                           SchemaBuilder payloadIdSchemaType,
+                                           Object payloadId,
+                                           String payloadType,
+                                           SchemaBuilder payloadSchemaType,
+                                           Object payload,
+                                           Map<String, Schema> extraFields,
+                                           Map<String, Object> extraValues) {
         SchemaBuilder schemaBuilder = SchemaBuilder.struct()
                 .field("id", SchemaBuilder.string())
                 .field("aggregatetype", SchemaBuilder.string())
-                .field("aggregateid", SchemaBuilder.string())
+                .field("aggregateid", payloadIdSchemaType)
                 .field("type", SchemaBuilder.string())
-                .field("payload", SchemaBuilder.string())
+                .field("payload", payloadSchemaType)
                 .field("is_deleted", SchemaBuilder.bool().optional());
 
         extraFields.forEach(schemaBuilder::field);

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -21,12 +21,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
-import static org.fest.assertions.Assertions.assertThat;
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.data.Envelope;
+import io.debezium.data.VerifyRecord;
+import io.debezium.doc.FixFor;
+import io.debezium.time.Timestamp;
 
 /**
  * Unit tests for {@link EventRouter}
@@ -353,7 +352,7 @@ public class EventRouterTest {
         Long expectedTimestamp = 14222264625338L;
 
         Map<String, Schema> extraFields = new HashMap<>();
-        extraFields.put("event_timestamp", Schema.INT64_SCHEMA);
+        extraFields.put("event_timestamp", Timestamp.schema());
 
         Map<String, Object> extraValues = new HashMap<>();
         extraValues.put("event_timestamp", expectedTimestamp);

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -387,7 +387,7 @@ public class EventRouterTest {
         final SourceRecord userEventRouted = router.apply(userEventRecord);
 
         assertThat(userEventRouted).isNotNull();
-        assertThat(userEventRouted.topic()).isEqualTo("outbox.event.user");
+        assertThat(userEventRouted.topic()).isEqualTo("outbox.event.User");
 
         final SourceRecord userUpdatedEventRecord = createEventRecord(
                 "ab720dd3-176d-40a6-96f3-6cf961d7df6a",
@@ -399,7 +399,7 @@ public class EventRouterTest {
         final SourceRecord userUpdatedEventRouted = router.apply(userUpdatedEventRecord);
 
         assertThat(userUpdatedEventRouted).isNotNull();
-        assertThat(userUpdatedEventRouted.topic()).isEqualTo("outbox.event.user");
+        assertThat(userUpdatedEventRouted.topic()).isEqualTo("outbox.event.User");
 
         final SourceRecord addressCreatedEventRecord = createEventRecord(
                 "ab720dd3-176d-40a6-96f3-6cf961d7df6a",
@@ -411,7 +411,7 @@ public class EventRouterTest {
         final SourceRecord addressCreatedEventRouted = router.apply(addressCreatedEventRecord);
 
         assertThat(addressCreatedEventRouted).isNotNull();
-        assertThat(addressCreatedEventRouted.topic()).isEqualTo("outbox.event.address");
+        assertThat(addressCreatedEventRouted.topic()).isEqualTo("outbox.event.Address");
     }
 
     @Test

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -68,6 +68,12 @@
             <artifactId>kafka-connect-avro-converter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.0.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -100,6 +100,7 @@ public abstract class AbstractConnectorTest implements Testing {
 
     @Before
     public final void initializeConnectorTestFramework() {
+        stopConnector();
         LoggingContext.forConnector(getClass().getSimpleName(), "", "test");
         keyJsonConverter = new JsonConverter();
         valueJsonConverter = new JsonConverter();

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractConnectorTest implements Testing {
 
     @Before
     public final void initializeConnectorTestFramework() {
-        stopConnector();
+        stopConnector(null);
         LoggingContext.forConnector(getClass().getSimpleName(), "", "test");
         keyJsonConverter = new JsonConverter();
         valueJsonConverter = new JsonConverter();


### PR DESCRIPTION
# What!?

Until we can make the major version upgrade, cherry-pick commits to the `EventRouter` SMT so we can start using it ASAP. I already hate myself for doing this, but fortunately the SMT is pretty much isolated from the rest of the code base

# Tests?!

After cherry-picking the relevant commits I made sure all tests were passing in the `debezium-core` component, and the integration tests defined in `OutboxEventRouterIT.java ` all pass as well

```
# mvn clean install -pl :debezium-core 
Tests run: 344, Failures: 0, Errors: 0, Skipped: 0

# mvn clean install -pl :debezium-connector-postgres -Pwal2json-decoder
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.994 sec - in io.debezium.connector.postgresql.OutboxEventRouterIT
```